### PR TITLE
Enable heavy ion simulations in pythia8.3

### DIFF
--- a/StRoot/StarGenerator/Pythia8_3_03/StarPythia8.cxx
+++ b/StRoot/StarGenerator/Pythia8_3_03/StarPythia8.cxx
@@ -1,7 +1,7 @@
 #include "StarPythia8.h"
 ClassImp(StarPythia8);
 
-#include "TDatabasePDG.h"
+#include "StarGenerator/UTIL/StarParticleData.h"
 #include "TParticlePDG.h"
 
 #include "StarGenerator/UTIL/StarRandom.h" 
@@ -71,9 +71,9 @@ int StarPythia8::Init()
 
   //
   // Initialize pythia based on the frame and registered beam momenta
-  // TODO: Switch to StarParticleDB
   //
-  TDatabasePDG &pdg  = (*TDatabasePDG::Instance());
+  StarParticleData& pdg = StarParticleData::instance();
+
   TParticlePDG *blue = pdg.GetParticle(myBlue); assert(blue);
   TParticlePDG *yell = pdg.GetParticle(myYell); assert(yell);
   //
@@ -85,8 +85,13 @@ int StarPythia8::Init()
   //
   // Setup event record based upon the beam species
   //
-  if ( mBlue == "proton" )         mEvent = new StarGenPPEvent();
-  else                             assert(0); // Pythia 8 does not (yet) support e+p collisions
+  mEvent = new StarGenPPEvent();
+  if ( mBlue == "proton" ) {
+    LOG_INFO << "pp or pA mode detected" << endm;
+  } 
+  else {
+    LOG_INFO << "AA (or eA) mode detected... event record will still be a pp event record." << endm;
+  }
   //
   // Make several particles stable which may cross the beam pipe,
   // and so the simulation package must be allowed to decide to


### PR DESCRIPTION
Pythia 8.3 supports heavy ion simulations using the Agantyr model.
The interface to pythia8, however, did not allow us to set beam particles
other than protons because

1) TDatabasePDG does not define heavy ions by default, and
2) We presumed that only the proton-proton event record would be used in pythia simualtions

We switch from TDatabasePDG to StarParticleData to be consistent with usage throughout StarGenerator, and because the heavy ions used in RHIC operations are defined there.   We also remove the "proton only restriction", allowing pp, pA and AA simulations.  

However, at this time we do not fill in the heavy ion part of the event record.   We will revisit if / when it becomes necessary.