### PR TITLE
Provide updates to Pythia6.h and StarPythia6.* to include common bloc…

### DIFF
--- a/StRoot/StarGenerator/Pythia6_2_22/Pythia6.h
+++ b/StRoot/StarGenerator/Pythia6_2_22/Pythia6.h
@@ -58,6 +58,23 @@ struct PySubs_t {
 extern "C" PySubs_t *address_of_pysubs();
 
 //
+// Interface to the PYDAT1 common block
+//      COMMON/PYDAT1/MSTU(200),PARU(200),MSTJ(200),PARJ(200)
+//
+#define address_of_pydat1 F77_NAME( address_of_pydat1, ADDRESS_OF_PYDAT1 )
+struct PyDat1_t{
+  Int_t    _mstu[200];
+  Double_t _paru[200];
+  Int_t    _mstj[200];
+  Double_t _parj[200];
+  Int_t    &mstu(Int_t i){return _mstu[i-1];}
+  Double_t &paru(Int_t i){return _paru[i-1];}
+  Int_t    &mstj(Int_t i){return _mstj[i-1];}
+  Double_t &parj(Int_t i){return _parj[i-1];}
+};
+extern "C" PyDat1_t *address_of_pydat1();
+
+//
 // Interface to the PYDAT3 common block
 //      COMMON/PYDAT3/MDCY(500,3),MDME(8000,2),BRAT(8000),KFDP(8000,5)
 //

--- a/StRoot/StarGenerator/Pythia6_2_22/StarPythia6.cxx
+++ b/StRoot/StarGenerator/Pythia6_2_22/StarPythia6.cxx
@@ -175,6 +175,9 @@ void StarPythia6::FillPP( StarGenEvent *event )
   myevent -> phiHat     = -999;
   
   myevent -> weight     = pypars().pari(7);
+  
+  myevent -> mstu72     = pydat1().mstu(72);
+  myevent -> mstu73     = pydat1().mstu(73);
 
 }
 // ----------------------------------------------------------------------------

--- a/StRoot/StarGenerator/Pythia6_2_22/StarPythia6.h
+++ b/StRoot/StarGenerator/Pythia6_2_22/StarPythia6.h
@@ -59,6 +59,8 @@ class StarPythia6 : public StarGenerator
   PyJets_t &pyjets(){ return *address_of_pyjets(); }
   /// Returns a reference to the /PYSUBS/ common block
   PySubs_t &pysubs(){ return *address_of_pysubs(); }
+  /// Returns a reference to the /PYDAT1/ common block
+  PyDat1_t &pydat1(){ return *address_of_pydat1(); }
   /// Returns a reference to the /PYDAT3/ common block
   PyDat3_t &pydat3(){ return *address_of_pydat3(); }
   /// Returns a reference to the /PYPARS/ common block

--- a/StRoot/StarGenerator/Pythia6_4_23/Pythia6.h
+++ b/StRoot/StarGenerator/Pythia6_4_23/Pythia6.h
@@ -62,6 +62,23 @@ struct PySubs_t {
 extern "C" PySubs_t *address_of_pysubs();
 
 //
+// Interface to the PYDAT1 common block
+//      COMMON/PYDAT1/MSTU(200),PARU(200),MSTJ(200),PARJ(200)
+//
+#define address_of_pydat1 F77_NAME( address_of_pydat1, ADDRESS_OF_PYDAT1 )
+struct PyDat1_t{
+  Int_t    _mstu[200];
+  Double_t _paru[200];
+  Int_t    _mstj[200];
+  Double_t _parj[200];
+  Int_t    &mstu(Int_t i){return _mstu[i-1];}
+  Double_t &paru(Int_t i){return _paru[i-1];}
+  Int_t    &mstj(Int_t i){return _mstj[i-1];}
+  Double_t &parj(Int_t i){return _parj[i-1];}
+};
+extern "C" PyDat1_t *address_of_pydat1();
+
+//
 // Interface to the PYDAT3 common block
 //      COMMON/PYDAT3/MDCY(500,3),MDME(8000,2),BRAT(8000),KFDP(8000,5)
 //

--- a/StRoot/StarGenerator/Pythia6_4_23/StarPythia6.cxx
+++ b/StRoot/StarGenerator/Pythia6_4_23/StarPythia6.cxx
@@ -52,6 +52,7 @@ StarPythia6::StarPythia6( const Char_t *name ) : StarGenerator(name)
 
   regtable("PyJets_t", "pyjets", address_of_pyjets() );
   regtable("PySubs_t", "pysubs", address_of_pysubs() );
+  regtable("PyDat1_t", "pydat1", address_of_pydat1() );
   regtable("PyDat3_t", "pydat3", address_of_pydat3() );
   regtable("PyPars_t", "pypars", address_of_pypars() );
   regtable("PyInt5_t", "pyint5", address_of_pyint5() );
@@ -194,6 +195,9 @@ void StarPythia6::FillPP( StarGenEvent *event )
   myevent -> phiHat     = -999;
   
   myevent -> weight     = pypars().pari(7);
+  
+  myevent -> mstu72     = pydat1().mstu(72);
+  myevent -> mstu73     = pydat1().mstu(73);
 
 }
 // ----------------------------------------------------------------------------

--- a/StRoot/StarGenerator/Pythia6_4_23/StarPythia6.h
+++ b/StRoot/StarGenerator/Pythia6_4_23/StarPythia6.h
@@ -59,6 +59,8 @@ class StarPythia6 : public StarGenerator
   static PyJets_t &pyjets(){ return *address_of_pyjets(); }
   /// Returns a reference to the /PYSUBS/ common block
   static PySubs_t &pysubs(){ return *address_of_pysubs(); }
+  /// Returns a reference to the /PYDAT1/ common block
+  static PyDat1_t &pydat1(){ return *address_of_pydat1(); }
   /// Returns a reference to the /PYDAT3/ common block
   static PyDat3_t &pydat3(){ return *address_of_pydat3(); }
   /// Returns a reference to the /PYPARS/ common block

--- a/StRoot/StarGenerator/Pythia6_4_28/Pythia6.h
+++ b/StRoot/StarGenerator/Pythia6_4_28/Pythia6.h
@@ -66,6 +66,23 @@ struct PySubs_t {
 extern "C" PySubs_t *address_of_pysubs();
 
 //
+// Interface to the PYDAT1 common block
+//      COMMON/PYDAT1/MSTU(200),PARU(200),MSTJ(200),PARJ(200)
+//
+#define address_of_pydat1 F77_NAME( address_of_pydat1, ADDRESS_OF_PYDAT1 )
+struct PyDat1_t{
+  Int_t    _mstu[200];
+  Double_t _paru[200];
+  Int_t    _mstj[200];
+  Double_t _parj[200];
+  Int_t    &mstu(Int_t i){return _mstu[i-1];}
+  Double_t &paru(Int_t i){return _paru[i-1];}
+  Int_t    &mstj(Int_t i){return _mstj[i-1];}
+  Double_t &parj(Int_t i){return _parj[i-1];}
+};
+extern "C" PyDat1_t *address_of_pydat1();
+
+//
 // Interface to the PYDAT3 common block
 //      COMMON/PYDAT3/MDCY(500,3),MDME(8000,2),BRAT(8000),KFDP(8000,5)
 //

--- a/StRoot/StarGenerator/Pythia6_4_28/StarPythia6.cxx
+++ b/StRoot/StarGenerator/Pythia6_4_28/StarPythia6.cxx
@@ -52,6 +52,7 @@ StarPythia6::StarPythia6( const Char_t *name ) : StarGenerator(name)
 
   regtable("PyJets_t", "pyjets", address_of_pyjets() );
   regtable("PySubs_t", "pysubs", address_of_pysubs() );
+  regtable("PyDat1_t", "pydat1", address_of_pydat1() );
   regtable("PyDat3_t", "pydat3", address_of_pydat3() );
   regtable("PyPars_t", "pypars", address_of_pypars() );
   regtable("PyInt5_t", "pyint5", address_of_pyint5() );
@@ -195,6 +196,9 @@ void StarPythia6::FillPP( StarGenEvent *event )
   myevent -> phiHat     = -999;
   
   myevent -> weight     = pypars().pari(7);
+  
+  myevent -> mstu72     = pydat1().mstu(72);
+  myevent -> mstu73     = pydat1().mstu(73);
 
 }
 // ----------------------------------------------------------------------------

--- a/StRoot/StarGenerator/Pythia6_4_28/StarPythia6.h
+++ b/StRoot/StarGenerator/Pythia6_4_28/StarPythia6.h
@@ -59,6 +59,8 @@ class StarPythia6 : public StarGenerator
   static PyJets_t &pyjets(){ return *address_of_pyjets(); }
   /// Returns a reference to the /PYSUBS/ common block
   static PySubs_t &pysubs(){ return *address_of_pysubs(); }
+  /// Returns a reference to the /PYDAT1/ common block
+  static PyDat1_t &pydat1(){ return *address_of_pydat1(); }
   /// Returns a reference to the /PYDAT3/ common block
   static PyDat3_t &pydat3(){ return *address_of_pydat3(); }
   /// Returns a reference to the /PYPARS/ common block


### PR DESCRIPTION
…k PYDAT1 for all available Pythia6 version under StarGenerator framework. The StarPythia6.* now includes the option to access common block members from address_of_pydat1 using the structure pydat1() function. The structure PyDat1_t is now included in the updates to the Pythia6.h.