### PR TITLE
Update urqmd commons

### DIFF
--- a/StRoot/StarGenerator/Hijing1_383/StarHijing.cxx
+++ b/StRoot/StarGenerator/Hijing1_383/StarHijing.cxx
@@ -204,6 +204,7 @@ Int_t StarHijing::Init()
   A["Cu"]=63;   Z["Cu"]=29;  type["Cu"]="A       ";
   A["U"] =238;  Z["U"]=92;   type["U"] ="A       ";
   A["Al"]=27;   Z["Al"]=13;  type["Al"]="A       ";
+  A["O"]=16;    Z["O"]=8;    type["O"] ="A       ";
 
   A["proton"]   =1;    Z["proton"]   =1;   type["proton"]   ="P       "; // important to map size of type onto character*8
   A["neutron"]  =1;    Z["neutron"]  =0;   type["neutron"]  ="N       ";

--- a/StRoot/StarGenerator/UrQMD4_0_0/StarUrQMD.cxx
+++ b/StRoot/StarGenerator/UrQMD4_0_0/StarUrQMD.cxx
@@ -159,6 +159,7 @@ Int_t StarUrQMD::Init()
       InputParametersDouble["ecm"]=mRootS;
     }
 
+#if 0
   std::vector<int> stablepdg = {
     111, // pi0
     211, // pi+/-
@@ -203,6 +204,8 @@ Int_t StarUrQMD::Init()
 
   // Lambda_c
   //  StableParticles.push_back("-69");
+
+#endif
 
   /// Initialize UrQMD:
   InitializeUrQMD();
@@ -607,13 +610,13 @@ void StarUrQMD::InitializeUrQMD()
       inputfile << "ecm " << mRootS << "\n";
     }
     /// Define calculation time: total time span, interval at which output is written (both in fm/c)
-    inputfile << "tim 200 200" << endl;
+    inputfile << "tim 100 100" << endl;
     /// This supresses the output files
     inputfile << "f13 \n #f14 \n f15 \n f16 \n #f17 \n #f18 \n f19 \n f20" << endl;
     /// This sets the number of events for UrQMD to run (but we aren't using this, so it doens't matter)
-    inputfile << "nev 1000" << endl;
+    inputfile << "nev 1" << endl;
     /// This sets the random number generator seed (but we aren't using UrQMD's random number generator, so this doens't matter)
-    inputfile << "rsd 111" << endl;
+    //    inputfile << "rsd 111" << endl;
 
     
     if ( SAttr("SET" )  ) {
@@ -625,7 +628,7 @@ void StarUrQMD::InitializeUrQMD()
 
 
     /// This marks the end of the input file
-    inputfile << "xxx and done" << endl;
+    inputfile << "xxx" << endl;
     inputfile.close();
 
     /// Initialize UrQMD
@@ -1019,9 +1022,9 @@ void StarUrQMD::InitializeUrQMD()
     /// This supresses the output files
     inputfile << "f13 \n #f14 \n f15 \n f16 \n #f17 \n #f18 \n f19 \n f20" << endl;
     /// This sets the number of events for UrQMD to run (but we aren't using this, so it doens't matter)
-    inputfile << "nev 1000" << endl;
+    inputfile << "nev 100" << endl;
     /// This sets the random number generator seed (but we aren't using UrQMD's random number generator, so this doens't matter)
-    inputfile << "rsd 111" << endl;
+    /////    inputfile << "rsd 111" << endl;
 
     
     if ( SAttr("SET" )  ) {

--- a/StRoot/StarGenerator/UrQMD4_0_0/StarUrQMD.cxx
+++ b/StRoot/StarGenerator/UrQMD4_0_0/StarUrQMD.cxx
@@ -105,6 +105,10 @@ Int_t StarUrQMD::Init()
   A["Au"] = 197;    Z["Au"] = 79;
   A["Cu"] =  64;    Z["Cu"] = 29;
   A["U"]  = 238;    Z["U"]  = 92;
+  A["O"]=16;    Z["O"]=8;    //type["O"] ="A       ";
+  
+  A["Zr96"]= 96;  Z["Zr96"]=40;  //type["Zr96"]="A       ";
+  A["Ru96"]= 96;  Z["Ru96"]=44;  //type["Ru96"]="A       ";
 
   A["proton"]   =1;    Z["proton"]   =1;
   A["neutron"]  =1;    Z["neutron"]  =0;

--- a/StRoot/StarGenerator/UrQMD4_0_0/UrQMD.h
+++ b/StRoot/StarGenerator/UrQMD4_0_0/UrQMD.h
@@ -1,5 +1,5 @@
-#ifndef __UrQMD3_3_1__
-#define __UrQMD3_3_1__
+#ifndef __UrQMD4_0_0__
+#define __UrQMD4_0_0__
 
 #include "StarCallf77.h"
 #include <string>
@@ -27,24 +27,23 @@ extern "C" ENERGIES_t *address_of_energies();
 
 #define sys F77_NAME(sys,SYS)
 struct SYS_t {
-    /*INTEGER npart, nbar, nmew, ctag, nsteps, uid_cnt, ranseed,
-     & event, Ap, At, Zp, Zt, eos, dectag, NHardRes, NSoftRes,
-     & NDecRes, NElColl, NBlColl
-       common /sys/ npart, nbar, nmes, ctag,nsteps,uid_cnt,
-     &             ranseed,event,Ap,At,Zp,Zt,eos,dectag,
-     &             NHardRes,NSoftRes,NDecRes,NElColl,NBlColl*/
-  /*
-      common /sys/ npart, nbar, nmes, ctag,nsteps,uid_cnt,
-     +             ranseed,event,Ap,At,Zp,Zt,eos,dectag,
-     +             NHardRes,NSoftRes,NDecRes,NElColl,NBlColl,
-     +             success,npartcoal,nclus
-  */
+    /*
+      integer npart, nbar, nmes, ctag, nsteps, uid_cnt, ranseed,
+     &        event, Ap, At, Zp, Zt, eos, dectag, NHardRes, NSoftRes,
+     &        NDecRes, NElColl, NBlColl
+      logical success
+      integer npartcoal, nclus
+      common /sys/ npart, nbar, nmes, ctag, nsteps, uid_cnt,
+     &             ranseed, event, Ap, At, Zp, Zt, eos, dectag,
+     &             NHardRes, NSoftRes, NDecRes, NElColl, NBlColl,
+     &             success, npartcoal, nclus
+    */
 
   Int_t  npart;
   Int_t  nbar;
-  Int_t  nmew;
+  Int_t  nmes;
   Int_t  ctag;
-  Int_t  nspteps;
+  Int_t  nsteps;
   Int_t  uid_cnt;
   Int_t  ranseed;
   Int_t  event;
@@ -107,7 +106,7 @@ struct SPDATA_t {
   Double_t  _spPauy[500];
   Double_t  _outPau[500];
   Double_t  _spCby[500];
-  Double_t  _outCby[500];
+  Double_t  _outCb[500];
   Double_t  _spYuky[500];
   Double_t  _outYuk[500];
   Double_t  _spSkyy[500];
@@ -118,7 +117,7 @@ struct SPDATA_t {
   Double_t  &spPauy( Int_t i ){return _spPauy[i-1]; }
   Double_t  &outPau( Int_t i ){return _outPau[i-1]; }
   Double_t  &spCby( Int_t i ){return _spCby[i-1]; }
-  Double_t  &outCby( Int_t i ){return _outCby[i-1]; }
+  Double_t  &outCb( Int_t i ){return _outCb[i-1]; }
   Double_t  &spYuky( Int_t i ){return _spYuky[i-1]; }
   Double_t  &outYuk( Int_t i ){return _outYuk[i-1]; }
   Double_t  &spSkyy( Int_t i ){return _spSkyy[i-1]; }
@@ -130,11 +129,10 @@ extern "C" SPDATA_t *address_of_spdata();
 
 #define isys F77_NAME(isys,ISYS)
 struct ISYS_t {
-   /* parameter (nmax = 40000) ! maximum number of particles
-      integer spin(nmax),ncoll(nmax),charge(nmax),strid(nmax),
-     &        ityp(nmax),lstcoll(nmax),iso3(nmax),origin(nmax),uid(nmax)
-      common/isys/spin,ncoll,charge,ityp,lstcoll,iso3,origin,strid,
-     &            uid*/
+   /* parameter (nmax = 100000) ! maximum number of particles
+      integer spin(nmax), ncoll(nmax), charge(nmax),
+     &        ityp(nmax), lstcoll(nmax), iso3(nmax), origin(nmax), uid(nmax)
+      common/isys/ spin, ncoll, charge, ityp, lstcoll, iso3, origin, uid */
   Int_t  _spin[100000];
   Int_t  _ncoll[100000];
   Int_t  _charge[100000];
@@ -146,6 +144,7 @@ struct ISYS_t {
   Int_t  _uid[100000];
   Int_t  &spin( Int_t i ){return _spin[i-1]; }
   Int_t  &ncoll( Int_t i ){return _ncoll[i-1]; }
+  Int_t  &charge( Int_t i ){return _charge[i-1]; }
   Int_t  &ityp( Int_t i ){return _ityp[i-1]; }
   Int_t  &lstcoll( Int_t i ){return _lstcoll[i-1]; }
   Int_t  &iso3( Int_t i ){return _iso3[i-1]; }
@@ -183,7 +182,7 @@ struct COOR_t {
   Double_t  &py( Int_t i ){return _py[i-1]; }
   Double_t  &pz( Int_t i ){return _pz[i-1]; }
   Double_t  &fmass( Int_t i ){return _fmass[i-1]; }
-  Double_t  &frww( Int_t i ){return _rww[i-1]; }
+  Double_t  &rww( Int_t i ){return _rww[i-1]; }
   Double_t  &dectime( Int_t i ){return _dectime[i-1]; }
 };
 extern "C" COOR_t *address_of_coor();
@@ -194,9 +193,9 @@ struct FRAG_t {
       real*8 tform(nmax), xtotfac(nmax)
       common /frag/ tform, xtotfac*/
   Double_t  _tform[100000];
-  Double_t  _xtotfrac[100000];
+  Double_t  _xtotfac[100000];
   Double_t  &tform( Int_t i ){return _tform[i-1]; }
-  Double_t  &xtotfrac( Int_t i ){return _xtotfrac[i-1]; }
+  Double_t  &xtotfac( Int_t i ){return _xtotfac[i-1]; }
 };
 extern "C" FRAG_t *address_of_frag();
 
@@ -315,7 +314,7 @@ extern "C" SISYS_t *address_of_sisys();
 struct SSYS_t {
     /*integer nspec
       common /ssys/ nspec*/
-  Int_t npsec;
+  Int_t nspec;
 };
 extern "C" SSYS_t *address_of_ssys();
 
@@ -397,5 +396,257 @@ void genevt( void );
 map<TString,Int_t> InputParametersInt;
 map<TString,Double_t> InputParametersDouble;
 map<TString,TString> InputParametersString;*/
+
+/*
+ * ============================================================================
+ * MISSING COMMON BLOCKS — UrQMD 4.0.0
+ * ============================================================================
+ * The following Fortran COMMON blocks exist in the UrQMD 4.0.0 source but have
+ * no corresponding C++ struct in this header.  C++ struct definitions and
+ * address_of_*() accessor declarations should be added here as they are needed
+ * by the STAR bridge code.
+ *
+ * NOTE on array index transposition:
+ *   Fortran arrays are column-major.  A Fortran array declared A(m,n) must be
+ *   declared in C++ as _A[n][m], with accessor A(i,j) = _A[j-1][i-1].
+ *
+ * NOTE on Fortran LOGICAL:
+ *   Fortran LOGICAL maps to Int_t (4 bytes) in C++.
+ *
+ * NOTE on blank (unnamed) COMMON:
+ *   The Fortran blank common "common cross" (without /name/ delimiters) has no
+ *   portable C-linkage symbol.  Accessing it from C++ requires a thin Fortran
+ *   wrapper function returning the address of the array.
+ *
+ * NOTE on C++ reserved keyword 'try':
+ *   The Fortran variable 'try' in /outcom/ cannot be used as a C++ method name.
+ *   Use the name try_() for the accessor.
+ *
+ * ----------------------------------------------------------------------------
+ * From coms.inc / coms90.inc  (new common blocks added in UrQMD 4)
+ * ----------------------------------------------------------------------------
+ *
+ *   /eccA/ — eccentricity observables
+ *     real*8 eccentricity, num_part, proton_part, neutron_part,
+ *    &       eps1, eps2, eps3, eps4
+ *     common /eccA/ eccentricity, num_part, proton_part, neutron_part,
+ *    &              eps1, eps2, eps3, eps4
+ *
+ *   /comseed/ — random-seed first-use flag
+ *     logical firstseed
+ *     common /comseed/ firstseed
+ *
+ *   /logic/ — per-particle potential-type flags
+ *     logical lsct(nmax), logSky, logYuk, logCb, logPau
+ *     common /logic/ lsct, logSky, logYuk, logCb, logPau
+ *
+ *   /mdprop/ — molecular-dynamics propagator temporary coordinate arrays
+ *     real*8 r0_t(nmax), rx_t(nmax), ry_t(nmax), rz_t(nmax)
+ *     common /mdprop/ r0_t, rx_t, ry_t, rz_t
+ *
+ *   /cluster/ — nuclear coalescence cluster data  (smax=500)
+ *     real*8    r0cl(500), rxcl(500), rycl(500), rzcl(500)
+ *     integer   lstcollcl(500), ncollcl(500)
+ *     real*8    p0cl(500), pxcl(500), pycl(500), pzcl(500), mcl(500)
+ *     integer   chgcl(500), isocl(500), itypcl(500), idcl(500)
+ *     common /cluster/ r0cl, rxcl, rycl, rzcl, lstcollcl,
+ *    &                 ncollcl, p0cl, pxcl, pycl, pzcl, mcl,
+ *    &                 chgcl, isocl, itypcl, idcl
+ *
+ *   blank common — ccbar-type crossing counter
+ *     integer cross(60)
+ *     common cross
+ *
+ * ----------------------------------------------------------------------------
+ * From inputs.inc / inputs90.inc
+ * ----------------------------------------------------------------------------
+ *
+ *   /inputs/ — primary event-configuration integers
+ *     integer nevents, spityp(2), prspflg, trspflg, spiso3(2),
+ *    &        outsteps, bflag, srtflag, efuncflag, nsrt, firstev, npb
+ *     common /inputs/ nevents, spityp, prspflg, trspflg,
+ *    &                spiso3, outsteps, bflag, srtflag, efuncflag,
+ *    &                nsrt, firstev, npb
+ *
+ *   /input2/ — beam kinematics
+ *     real*8 srtmin, srtmax, pbeam, betann, betatar, betapro, pbmin, pbmax
+ *     common /input2/ srtmin, srtmax, pbeam, betann, betatar, betapro,
+ *    &                pbmin, pbmax
+ *
+ *   /ProTarInts/ — projectile/target integer particle data
+ *     (AAmax=300, MaxNTest=20 → dim = AAmax*MaxNTest = 6000)
+ *     integer PT_iso3(6000,2), PT_ityp(6000,2), PT_spin(6000,2),
+ *    &        PT_charge(6000,2), PT_AA(2), PT_uid(6000,2)
+ *     common /ProTarInts/ PT_iso3, PT_ityp, PT_spin, PT_charge,
+ *    &                    PT_AA, PT_uid
+ *     C++ layout: PT_iso3(6000,2) → _PT_iso3[2][6000], accessor [j-1][i-1]
+ *
+ *   /ProTarReals/ — projectile/target real particle data
+ *     real*8 PT_r0(6000,2), PT_rx(6000,2), PT_ry(6000,2), PT_rz(6000,2),
+ *    &       PT_fmass(6000,2), PT_dectime(6000,2),
+ *    &       PT_p0(6000,2), PT_px(6000,2), PT_py(6000,2), PT_pz(6000,2),
+ *    &       PT_rho(6000,2), PT_pmax(6000,2)
+ *     common /ProTarReals/ PT_r0, PT_rx, PT_ry, PT_rz, PT_fmass, PT_dectime,
+ *    &                     PT_p0, PT_px, PT_py, PT_pz, PT_rho, PT_pmax
+ *     C++ layout: all (6000,2) → [2][6000], accessor [j-1][i-1]
+ *
+ * ----------------------------------------------------------------------------
+ * From options.inc / options90.inc
+ * ----------------------------------------------------------------------------
+ *
+ *   /options/ — simulation option arrays
+ *     integer CTOption(400)
+ *     real*8  CTParam(400)
+ *     common /options/ CTOption, CTParam
+ *
+ *   /optstrings/ — option documentation character arrays
+ *     character ctodc(400)*2, ctpdc(400)*2
+ *     common /optstrings/ ctodc, ctpdc
+ *     C++ type: char _ctodc[400][2], char _ctpdc[400][2]  (not null-terminated)
+ *
+ *   /loptions/ — logical option flags
+ *     logical fixedseed, bf13, bf14, bf15, bf16, bf19, bf20
+ *     common /loptions/ fixedseed, bf13, bf14, bf15, bf16, bf19, bf20
+ *
+ *   /stables/ — stable-particle configuration
+ *     integer nstable, stabvec(20)
+ *     common /stables/ nstable, stabvec
+ *
+ * ----------------------------------------------------------------------------
+ * From newpart.inc / newpart90.inc
+ * ----------------------------------------------------------------------------
+ *
+ *   /inewpart/ — new-particle integer data per collision  (mprt=1000, oprt=2)
+ *     integer itypnew(mprt), i3new(mprt), itot(mprt), inew(mprt),
+ *    &        nexit, iline, pslot(oprt), nstring1, nstring2,
+ *    &        itypold(oprt), iso3old(oprt)
+ *     common /inewpart/ itypnew, i3new, itot, inew, nexit, iline,
+ *    &                  pslot, nstring1, nstring2, itypold, iso3old
+ *
+ *   /rnewpart/ — new-particle real data per collision
+ *     real*8 pnew(5,mprt), xnew(4,mprt), betax, betay, betaz,
+ *    &       pold(5,oprt), p0nn, pxnn, pynn, pznn, pnn,
+ *    &       mstring(oprt), pnnout, xtotfacold(oprt)
+ *     common /rnewpart/ pnew, xnew, betax, betay, betaz, pold,
+ *    &                  p0nn, pxnn, pynn, pznn, pnn, mstring,
+ *    &                  pnnout, xtotfacold
+ *     C++ layout: pnew(5,1000) → _pnew[1000][5], accessor [j-1][i-1]
+ *                 xnew(4,1000) → _xnew[1000][4], accessor [j-1][i-1]
+ *                 pold(5,2)    → _pold[2][5],     accessor [j-1][i-1]
+ *
+ *   /fnewpart/ — leading-hadron formation factor  (mprt=1000)
+ *     real*8 leadfac(mprt)
+ *     common /fnewpart/ leadfac
+ *
+ * ----------------------------------------------------------------------------
+ * From comhis.inc  (entirely new file in UrQMD 4)
+ * ----------------------------------------------------------------------------
+ *
+ *   /historyhead/ — collision-history header arrays  (wwmax=20000)
+ *     integer   hisnin(wwmax), hisnexit(wwmax), hisiline(wwmax),
+ *    &           hisctag(wwmax)
+ *     real*8    hisacttime(wwmax), hissqrts(wwmax), hisstot(wwmax),
+ *    &           hissigpart(wwmax), hiscdens(wwmax)
+ *     common /historyhead/ hisnin, hisnexit, hisiline, hisctag,
+ *    &                     hisacttime, hissqrts, hisstot, hissigpart,
+ *    &                     hiscdens
+ *
+ *   /historyin/ — ingoing-particle collision history  (wwmax=20000, inmax=10)
+ *     integer   INind(wwmax,inmax)
+ *     real*8    INr0(wwmax,inmax), INrx(wwmax,inmax), INry(wwmax,inmax),
+ *    &           INrz(wwmax,inmax), INp0(wwmax,inmax), INpx(wwmax,inmax),
+ *    &           INpy(wwmax,inmax), INpz(wwmax,inmax), INmass(wwmax,inmax)
+ *     integer   INityp(wwmax,inmax), INiso3(wwmax,inmax), INch(wwmax,inmax),
+ *    &           INlcoll(wwmax,inmax), INcoll(wwmax,inmax),
+ *    &           INistr(wwmax,inmax), INorigin(wwmax,inmax)
+ *     common /historyin/ INind, INr0, INrx, INry, INrz,
+ *    &                   INp0, INpx, INpy, INpz, INmass, INityp,
+ *    &                   INiso3, INch, INlcoll, INcoll, INistr, INorigin
+ *     C++ layout: all (20000,10) → [10][20000], accessor [j-1][i-1]
+ *
+ *   /historyout/ — outgoing-particle collision history  (wwmax=20000, outmax=50)
+ *     Same structure as /historyin/ but prefixed OUT and with outmax=50.
+ *     integer   OUTind(wwmax,outmax), OUTityp, OUTiso3, OUTch,
+ *    &           OUTlcoll, OUTcoll, OUTistr, OUTorigin  (all (wwmax,outmax))
+ *     real*8    OUTr0, OUTrx, OUTry, OUTrz, OUTp0, OUTpx, OUTpy, OUTpz,
+ *    &           OUTmass  (all (wwmax,outmax))
+ *     common /historyout/ OUTind, OUTr0, OUTrx, OUTry, OUTrz,
+ *    &                    OUTp0, OUTpx, OUTpy, OUTpz, OUTmass, OUTityp,
+ *    &                    OUTiso3, OUTch, OUTlcoll, OUTcoll, OUTistr, OUTorigin
+ *     C++ layout: all (20000,50) → [50][20000], accessor [j-1][i-1]
+ *
+ *   /historyrec/ — reconstructable-resonance record  (resomax=40000)
+ *     integer   resctr, www
+ *     real*8    RECr0(resomax), RECrx(resomax), RECry(resomax),
+ *    &           RECrz(resomax), RECp0(resomax), RECpx(resomax),
+ *    &           RECpy(resomax), RECpz(resomax), RECmass(resomax)
+ *     integer   RECityp(resomax), RECiso3(resomax), RECch(resomax),
+ *    &           REClcoll(resomax), RECcoll(resomax), RECorigin(resomax)
+ *     integer   RECind(resomax,0:4)    ! NOTE: second index is 0-based
+ *     real*8    ORIr0(resomax), ORIrx(resomax), ORIry(resomax),
+ *    &           ORIrz(resomax), ORIp0(resomax), ORIpx(resomax),
+ *    &           ORIpy(resomax), ORIpz(resomax), ORImass(resomax)
+ *     integer   ORIityp(resomax), ORIiso3(resomax), ORIch(resomax),
+ *    &           ORIlcoll(resomax), ORIcoll(resomax), ORIorigin(resomax)
+ *     common /historyrec/ resctr, www, RECr0, RECrx, RECry, RECrz,
+ *    &                    RECp0, RECpx, RECpy, RECpz, RECmass,
+ *    &                    RECityp, RECiso3, RECch, REClcoll, RECcoll,
+ *    &                    RECorigin, RECind,
+ *    &                    ORIr0, ORIrx, ORIry, ORIrz, ORIp0, ORIpx,
+ *    &                    ORIpy, ORIpz, ORImass, ORIityp, ORIiso3, ORIch,
+ *    &                    ORIlcoll, ORIcoll, ORIorigin
+ *     C++ layout: RECind(resomax,0:4) → _RECind[5][40000]
+ *                 accessor: RECind(i,j) = _RECind[j][i-1]  (j already 0-based)
+ *
+ * ----------------------------------------------------------------------------
+ * From comstr.inc
+ * ----------------------------------------------------------------------------
+ *
+ *   /FRGSPA/ — scalar string-fragmentation parameters  (njspin=8)
+ *     real*8 PJSPNS, PMIX1S(3,njspin), PMIX2S(3,njspin), PBARS, PARQLS, PARRS
+ *     COMMON /FRGSPA/ PJSPNS, PMIX1S, PMIX2S, PBARS, PARQLS, PARRS
+ *     C++ layout: PMIX1S(3,8) → _PMIX1S[8][3], accessor [j-1][i-1]
+ *
+ *   /FRGCPA/ — charm string-fragmentation parameters  (njspin=8)
+ *     real*8 PJSPNC, PMIX1C(3,njspin), PMIX2C(3,njspin), PBARC
+ *     COMMON /FRGCPA/ PJSPNC, PMIX1C, PMIX2C, PBARC
+ *     C++ layout: PMIX1C(3,8) → _PMIX1C[8][3], accessor [j-1][i-1]
+ *
+ *   /coparm/ — combinatorial-background fragmentation probabilities (njspin=8)
+ *     real*8 parm(njspin)
+ *     COMMON /coparm/ parm
+ *
+ *   /CONST/ — runtime value of pi  (distinct from the parameter pi in coms.inc)
+ *     real*8 PI
+ *     COMMON /CONST/ PI
+ *
+ * ----------------------------------------------------------------------------
+ * From freezeout.inc
+ * ----------------------------------------------------------------------------
+ *
+ *   /frcoor/ — freeze-out space-time coordinates  (nmax=100000)
+ *     real*8 frr0(nmax), frrx(nmax), frry(nmax), frrz(nmax),
+ *    &       frp0(nmax), frpx(nmax), frpy(nmax), frpz(nmax)
+ *     common /frcoor/ frr0, frrx, frry, frrz, frp0, frpx, frpy, frpz
+ *
+ * ----------------------------------------------------------------------------
+ * From outcom.inc
+ * ----------------------------------------------------------------------------
+ *
+ *   /outcom/ — per-collision output buffer  (3-particle slots)
+ *     real*8 tsqrts, tstot, tsigpart
+ *     real*8 tr0(3), trx(3), try(3), trz(3), ttform(3), txtotfac(3),
+ *    &       tp0(3), tpx(3), tpy(3), tpz(3), tm(3)
+ *     integer tind(3), tityp(3), tiso3(3), tcoll(3), tstrange(3),
+ *    &        tlcoll(3), tcharge(3), torigin(3), tuid(3)
+ *     common /outcom/ tsqrts, tstot, tsigpart,
+ *    &                tr0, trx, try, trz, ttform, txtotfac,
+ *    &                tp0, tpx, tpy, tpz, tm,
+ *    &                tind, tityp, tiso3, tcoll, tstrange,
+ *    &                tlcoll, tcharge, torigin, tuid
+ *     WARNING: 'try' is a C++ reserved keyword — the accessor must be try_()
+ *
+ * ============================================================================
+ */
 
 #endif

--- a/StRoot/StarGenerator/UrQMD4_0_0/gnuranf.F
+++ b/StRoot/StarGenerator/UrQMD4_0_0/gnuranf.F
@@ -8,7 +8,10 @@ c
 cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
       implicit none
-
+      real *8 ranf, ranfstar
+      integer idummy
+      ranf = ranfstar( idummy )
+#if 0
       include 'coms.inc'
 
       integer idummy, iseed, oldseed
@@ -21,7 +24,7 @@ cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
             call error ('ranf','ranf gives endpoint values',ranf,3)
          endif
       endif
-
+#endif
       return
       end
 

--- a/StRoot/StarGenerator/UrQMD4_0_0/pythia6409.F
+++ b/StRoot/StarGenerator/UrQMD4_0_0/pythia6409.F
@@ -68498,6 +68498,9 @@ C...0 and 1, excluding the endpoints.
 C...Double precision and integer declarations.
       IMPLICIT DOUBLE PRECISION(A-H, O-Z)
       IMPLICIT INTEGER(I-N)
+
+      pyr=pyrstar(idummy)
+#if 0      
       INTEGER PYK,PYCHGE,PYCOMP
 C...Commonblocks.
       COMMON/PYDATR/MRPY(6),RRPY(100)
@@ -68563,7 +68566,7 @@ C...Update counters. Random number to output.
         MRPY3=0
       ENDIF
       PYR=RUNI
- 
+ #endif
       RETURN
       END
  


### PR DESCRIPTION
Common block definitions in UrQMD4 have changed relative to UrQMD3.  The StarUrQMD c++ bridge did not update the c-structs they map onto.  This commit resolves that, and also maps the RNGs onto StarRandom.